### PR TITLE
docs: add a Discord badge and fix the existing Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ TODO: adjust size
       <img src="https://img.shields.io/badge/commits-3-yellow" alt="Number of Commits">
   </a>
   <a href="https://discord.gg/5jVXv5A">
-      <img src="https://img.shields.io/badge/join0us-on%20Discord-blue" alt="Join us on Discord">
+      <img src="https://img.shields.io/badge/join%20us%20-%20on%20Discord-blue" alt="Join us on Discord">
   </a>
 
 # Purpose

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To spread joy and create wealth by first increasing the total number of Clojure 
 1. [Want to be a Mentor?](https://github.com/athensresearch/ClojureFam/blob/master/doc/clojurefam-overview.md#why-contribute-as-a-mentor)
 1. [Onboarding for New Clojurians](https://www.notion.so/Onboarding-for-New-Clojurians-b34b38f30902448cae68afffa02425c1)
 1. [Athens Research - Open-Source Networked Thought Tools](https://github.com/athensresearch/athens)
-1. [Join our Discord](https://discord.gg/RwVjh6u)
+1. [Join our Discord](https://discord.gg/5jVXv5A)
 
 # Contribute
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ TODO: adjust size
   <a href="https://github.com/athensresearch/ClojureFam/blob/master/doc/learner-commits.md">
       <img src="https://img.shields.io/badge/commits-3-yellow" alt="Number of Commits">
   </a>
+  <a href="https://discord.gg/5jVXv5A">
+      <img src="https://img.shields.io/badge/join0us-on%20Discord-blue" alt="Join us on Discord">
+  </a>
 
 # Purpose
 To spread joy and create wealth by first increasing the total number of Clojure developers in the world, and second by strengthening the relationships within the global Clojure community.


### PR DESCRIPTION
The link is configured to never expire and to point to the #school-builders channel.

I thought making the Discord link more visible would be a good idea :slightly_smiling_face: 