### PR TITLE
Fix link to ClojureFam Roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/athensresearch/ClojureFam/blob/master/doc/clojurefam-rosters.mdh">  
+  <a href="https://github.com/athensresearch/ClojureFam/blob/master/doc/clojurefam-rosters.md">  
       <img src="https://img.shields.io/badge/cohorts-5-green" alt="Number of Cohorts">
   </a>
   <a href="https://github.com/athensresearch/ClojureFam/blob/master/doc/clojurefam-rosters.md">


### PR DESCRIPTION
Current link has an extra 'h' at the end (https://github.com/athensresearch/ClojureFam/blob/master/doc/clojurefam-rosters.mdh) which breaks it.
This PR removes the 'h' and fixes the link.