### PR TITLE
Automate learner badge count

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
       <img src="https://img.shields.io/badge/cohorts-5-green" alt="Number of Cohorts">
   </a>
   <a href="https://github.com/athensresearch/ClojureFam/blob/master/doc/clojurefam-rosters.md">
-      <img src="https://img.shields.io/badge/learners-31-orange" alt="Number of Learners">
+      <img src="https://img.shields.io/github/issues-raw/athensresearch/clojurefam/learner?label=learners" alt="Number of Learners">
   </a>
   <a href="https://github.com/athensresearch/ClojureFam/blob/master/doc/learner-commits.md">
       <img src="https://img.shields.io/badge/commits-3-yellow" alt="Number of Commits">


### PR DESCRIPTION
Instead of updating the badge every time we can just use this badge that counts the number of issues with the learner tag. We could also automate the number of learner's PR by adding a similar label on the PRs in the Athens repo.

We should also adjust the labels to match the 31 number. Some may be missing?