### PR TITLE
disclaimer redirecting readers to handbook added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+*5/10/2021 Update*
+All Clojurefam docs have been moved to https://athensresearch.gitbook.io/handbook/school-of-athens/clojurefam. Go there for the latest information while this repo is being repurposed/redesigned to accomodate more types of learners.
+
 <h1 align="center">ClojureFam</h1>
 
 <p align="center">


### PR DESCRIPTION
disclaimer added to the top of the readme telling readers to go to the handbook for the latest information